### PR TITLE
Improve CU consumption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3868,7 +3868,6 @@ checksum = "8b8a731ed60e89177c8a7ab05fe0f1511cedd3e70e773f288f9de33a9cfdc21e"
 name = "solana-nostd-entrypoint"
 version = "0.3.3"
 dependencies = [
- "arrayvec",
  "solana-program",
 ]
 

--- a/solana-nostd-entrypoint/Cargo.toml
+++ b/solana-nostd-entrypoint/Cargo.toml
@@ -14,5 +14,4 @@ repository = "https://github.com/cavemanloverboy/solana-nostd-entrypoint"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-arrayvec = { version = "0.7.4", default-features = false }
 solana-program = "1.18.1"

--- a/solana-nostd-entrypoint/src/entrypoint_nostd.rs
+++ b/solana-nostd-entrypoint/src/entrypoint_nostd.rs
@@ -126,6 +126,8 @@ macro_rules! entrypoint_nostd_no_duplicates_no_program {
     };
 }
 
+/// # Safety
+/// solana entrypoint
 pub unsafe fn deserialize_nostd<'a, const MAX_ACCOUNTS: usize>(
     input: *mut u8,
     accounts: &mut [MaybeUninit<NoStdAccountInfo>],
@@ -209,6 +211,8 @@ pub unsafe fn deserialize_nostd<'a, const MAX_ACCOUNTS: usize>(
     (program_id, processed, instruction_data)
 }
 
+/// # Safety
+/// solana entrypoint
 pub unsafe fn deserialize_nostd_no_dup<'a, const MAX_ACCOUNTS: usize>(
     input: *mut u8,
     accounts: &mut [MaybeUninit<NoStdAccountInfo>],
@@ -275,6 +279,8 @@ pub unsafe fn deserialize_nostd_no_dup<'a, const MAX_ACCOUNTS: usize>(
     Some((program_id, processed, instruction_data))
 }
 
+/// # Safety
+/// solana entrypoint
 pub unsafe fn deserialize_nostd_no_program<'a, const MAX_ACCOUNTS: usize>(
     input: *mut u8,
     accounts: &mut [MaybeUninit<NoStdAccountInfo>],
@@ -355,6 +361,8 @@ pub unsafe fn deserialize_nostd_no_program<'a, const MAX_ACCOUNTS: usize>(
     (processed, instruction_data)
 }
 
+/// # Safety
+/// solana entrypoint
 pub unsafe fn deserialize_nostd_no_dup_no_program<'a, const MAX_ACCOUNTS: usize>(
     input: *mut u8,
     accounts: &mut [MaybeUninit<NoStdAccountInfo>],
@@ -738,23 +746,23 @@ impl NoStdAccountInfo {
         unsafe { (*self.inner).data_len }
     }
 
-    /// # SAFETY
+    /// # Safety
     /// This does not check or modify the 4-bit refcell. Useful when instruction has verified non-duplicate accounts.
     pub unsafe fn unchecked_borrow_lamports(&self) -> &u64 {
         &(*self.inner).lamports
     }
-    /// # SAFETY
+    /// # Safety
     /// This does not check or modify the 4-bit refcell. Useful when instruction has verified non-duplicate accounts.
     #[allow(clippy::mut_from_ref)]
     pub unsafe fn unchecked_borrow_mut_lamports(&self) -> &mut u64 {
         &mut (*self.inner).lamports
     }
-    /// # SAFETY
+    /// # Safety
     /// This does not check or modify the 4-bit refcell. Useful when instruction has verified non-duplicate accounts.
     pub unsafe fn unchecked_borrow_data(&self) -> &[u8] {
         core::slice::from_raw_parts(self.data_ptr(), (*self.inner).data_len)
     }
-    /// # SAFETY
+    /// # Safety
     /// This does not check or modify the 4-bit refcell. Useful when instruction has verified non-duplicate accounts.
     #[allow(clippy::mut_from_ref)]
     pub unsafe fn unchecked_borrow_mut_data(&self) -> &mut [u8] {

--- a/solana-nostd-entrypoint/src/entrypoint_nostd.rs
+++ b/solana-nostd-entrypoint/src/entrypoint_nostd.rs
@@ -28,9 +28,15 @@ macro_rules! entrypoint_nostd {
 
             let (program_id, num_accounts, instruction_data) =
                 unsafe { $crate::deserialize_nostd::<$accounts>(input, &mut accounts) };
+
+            let account_infos = core::slice::from_raw_parts(
+                accounts.as_ptr() as *const NoStdAccountInfo,
+                num_accounts
+            );
+
             match $process_instruction(
                 &program_id,
-                core::slice::from_raw_parts(accounts.as_ptr() as _, num_accounts),
+                account_infos,
                 &instruction_data,
             ) {
                 Ok(()) => solana_program::entrypoint::SUCCESS,
@@ -59,9 +65,15 @@ macro_rules! entrypoint_nostd_no_duplicates {
                 solana_program::log::sol_log("a duplicate account was found");
                 return u64::MAX;
             };
+
+            let account_infos = core::slice::from_raw_parts(
+                accounts.as_ptr() as *const NoStdAccountInfo,
+                num_accounts
+            );
+            
             match $process_instruction(
                 &program_id,
-                core::slice::from_raw_parts(accounts.as_ptr() as _, num_accounts),
+                account_infos,
                 &instruction_data,
             ) {
                 Ok(()) => solana_program::entrypoint::SUCCESS,
@@ -85,8 +97,12 @@ macro_rules! entrypoint_nostd_no_program {
 
             let (num_accounts, instruction_data) =
                 unsafe { $crate::deserialize_nostd_no_program::<$accounts>(input, &mut accounts) };
+                    
+            let account_infos = core::slice::from_raw_parts(
+                accounts.as_ptr() as *const NoStdAccountInfo,
+                num_accounts);
             match $process_instruction(
-                core::slice::from_raw_parts(accounts.as_ptr() as _, num_accounts),
+                account_infos,
                 &instruction_data,
             ) {
                 Ok(()) => solana_program::entrypoint::SUCCESS,
@@ -115,8 +131,12 @@ macro_rules! entrypoint_nostd_no_duplicates_no_program {
                 solana_program::log::sol_log("a duplicate account was found");
                 return u64::MAX;
             };
+
+            let account_infos = core::slice::from_raw_parts(
+                accounts.as_ptr() as *const NoStdAccountInfo,
+                num_accounts);
             match $process_instruction(
-                core::slice::from_raw_parts(accounts.as_ptr() as _, num_accounts),
+                account_infos,
                 &instruction_data,
             ) {
                 Ok(()) => solana_program::entrypoint::SUCCESS,

--- a/solana-nostd-entrypoint/src/entrypoint_nostd.rs
+++ b/solana-nostd-entrypoint/src/entrypoint_nostd.rs
@@ -654,6 +654,7 @@ impl NoStdAccountInfo {
     }
     /// # SAFETY
     /// This does not check or modify the 4-bit refcell. Useful when instruction has verified non-duplicate accounts.
+    #[allow(clippy::mut_from_ref)]
     pub unsafe fn unchecked_borrow_mut_lamports(&self) -> &mut u64 {
         &mut (*self.inner).lamports
     }
@@ -664,6 +665,7 @@ impl NoStdAccountInfo {
     }
     /// # SAFETY
     /// This does not check or modify the 4-bit refcell. Useful when instruction has verified non-duplicate accounts.
+    #[allow(clippy::mut_from_ref)]
     pub unsafe fn unchecked_borrow_mut_data(&self) -> &mut [u8] {
         core::slice::from_raw_parts_mut(self.data_ptr(), (*self.inner).data_len)
     }

--- a/solana-nostd-entrypoint/src/entrypoint_nostd.rs
+++ b/solana-nostd-entrypoint/src/entrypoint_nostd.rs
@@ -70,7 +70,7 @@ macro_rules! entrypoint_nostd_no_duplicates {
                 accounts.as_ptr() as *const NoStdAccountInfo,
                 num_accounts
             );
-            
+
             match $process_instruction(
                 &program_id,
                 account_infos,
@@ -161,11 +161,7 @@ pub unsafe fn deserialize_nostd<'a, const MAX_ACCOUNTS: usize>(
 
     let processed = if num_accounts > 0 {
         // we will only process up to MAX_ACCOUNTS
-        let processed = if num_accounts > MAX_ACCOUNTS {
-            MAX_ACCOUNTS
-        } else {
-            num_accounts
-        };
+        let processed = num_accounts.min(MAX_ACCOUNTS);
 
         for i in 0..processed {
             let dup_info = *(input.add(offset) as *const u8);
@@ -248,11 +244,7 @@ pub unsafe fn deserialize_nostd_no_dup<'a, const MAX_ACCOUNTS: usize>(
     #[allow(clippy::needless_range_loop)]
     let processed = if num_accounts > 0 {
         // we will only process up to MAX_ACCOUNTS
-        let processed = if num_accounts > MAX_ACCOUNTS {
-            MAX_ACCOUNTS
-        } else {
-            num_accounts
-        };
+        let processed = num_accounts.min(MAX_ACCOUNTS);
 
         for i in 0..processed {
             let dup_info = *(input.add(offset) as *const u8);
@@ -315,11 +307,7 @@ pub unsafe fn deserialize_nostd_no_program<'a, const MAX_ACCOUNTS: usize>(
     // Account Infos
     let processed = if num_accounts > 0 {
         // we will only process up to MAX_ACCOUNTS
-        let processed = if num_accounts > MAX_ACCOUNTS {
-            MAX_ACCOUNTS
-        } else {
-            num_accounts
-        };
+        let processed = num_accounts.min(MAX_ACCOUNTS);
 
         for i in 0..processed {
             let dup_info = *(input.add(offset) as *const u8);
@@ -398,11 +386,7 @@ pub unsafe fn deserialize_nostd_no_dup_no_program<'a, const MAX_ACCOUNTS: usize>
     #[allow(clippy::needless_range_loop)]
     let processed = if num_accounts > 0 {
         // we will only process up to MAX_ACCOUNTS
-        let processed = if num_accounts > MAX_ACCOUNTS {
-            MAX_ACCOUNTS
-        } else {
-            num_accounts
-        };
+        let processed = num_accounts.min(MAX_ACCOUNTS);
 
         for i in 0..processed {
             let dup_info = *(input.add(offset) as *const u8);


### PR DESCRIPTION
While benchmarking different entrypoints in [`eisodos`](https://github.com/febo/eisodos), it seemed that `solana-nostd-entrypoint` is currently consuming more CUs by:
- Using the `arrayvec` library instead of a static array
- Having extra branching statements (`if`) when parsing accounts

This PR addresses both of these points, which leads to improvements of up to 50% when parsing 64 accounts – even when parsing a single account there are improvements of ~10%. Overall, the more accounts, the bigger the improvement.

The original performance of the entrypoint is:

| Name                   | CUs   | Delta |
|------------------------|-------|-------|
| ping                   | 18    | -     |
| log                    | 121   | -     |
| u64 data + 1 account   | 50    | -     |
| u64 data + 5 accounts  | 142   | -     |
| u64 data + 10 accounts | 257   | -     |
| u64 data + 20 accounts | 487   | -     |
| u64 data + 32 accounts | 763   | -     |
| u64 data + 64 accounts | 1,499 | -     |

### Replacing `arrayvec`

Instead of using `arrayvec`, this PR uses a static array of `[MaybeUninit<NoStdAccountInfo>]` and keeps track of how many accounts were actually present in the input. Only the initialized `NoStdAccountInfo` accounts are then forwarded to the program entrypoint. 

This change improved the CUs consumption to:

| Name                   | CUs  | Delta |
|------------------------|------|-------|
| ping                   | 18   | --    |
| log                    | 121  | --    |
| u64 data + 1 account   | 44   | -6    |
| u64 data + 5 accounts  | 116  | -26   |
| u64 data + 10 accounts | 206  | -51   |
| u64 data + 20 accounts | 386  | -101  |
| u64 data + 32 accounts | 602  | -161  |
| u64 data + 64 accounts | 1178 | -321  |

### Reducing branching

Currently, each iteration of the loop that "parses" an account has a check to see whether there was space for the account or not:
```rust
if accounts
   .try_push(NoStdAccountInfo {
     inner: account_info as *const _ as *mut _,
   })
   .is_err()
{
   log::sol_log("ArrayVec is full. Truncating input accounts");
};
```

Instead of having this check, we can split the loop: (1) one loop that goes through the accounts that we know there are space for them; (2) another loop to parse the accounts that we don't have space.

Adding this change, we can further improve CUs consumption:

| Name                   | CUs | Delta |
|------------------------|-----|-------|
| ping                   | 17  | -1    |
| log                    | 120 | -1    |
| u64 data + 1 account   | 43  | -1    |
| u64 data + 5 accounts  | 99  | -17   |
| u64 data + 10 accounts | 169 | -37   |
| u64 data + 20 accounts | 309 | -77   |
| u64 data + 32 accounts | 477 | -125  |
| u64 data + 64 accounts | 926 | -252  |
