### PR TITLE
Use log full path on `basic_panic_impl` macro

### DIFF
--- a/solana-nostd-entrypoint/src/lib.rs
+++ b/solana-nostd-entrypoint/src/lib.rs
@@ -34,7 +34,7 @@ macro_rules! basic_panic_impl {
         #[cfg(target_os = "solana")]
         #[no_mangle]
         fn custom_panic(_info: &core::panic::PanicInfo<'_>) {
-            log::sol_log("panicked!");
+            $crate::solana_program::log::sol_log("panicked!");
         }
     };
 }


### PR DESCRIPTION
This PR uses the full path for the `log` reference on the `basic_panic_impl` to avoid having to add an import the `log` – importing the `log` without any other use generates a clippy warning.

Current error when not explicitly importing `solana_program::log`:

![image](https://github.com/user-attachments/assets/2ea6fe23-0274-488c-986b-46ee7f3dc574)
